### PR TITLE
ADDED: Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Ignore all files and folders by default
+**
+
+# Allow the src folder
+!src/
+
+# Optionally, allow files within the src folder (if needed)
+!src/**
+
+!pyproject.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Use an official Python 3.11 base image
+FROM python:3.11-slim
+
+# Set environment variables
+ENV CONDA_ENV=care_env
+ENV LANG C.UTF-8
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    build-essential \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Miniconda
+RUN curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh && \
+    bash miniconda.sh -b -p /opt/conda && \
+    rm miniconda.sh && \
+    /opt/conda/bin/conda init bash
+
+# Set PATH for conda
+ENV PATH /opt/conda/bin:$PATH
+
+# Copy all files (except the specified in .dockerignore) from the repo to the /care directory in the container
+COPY . /care
+
+# Set working directory
+WORKDIR /care
+
+# Create and activate conda environment
+RUN conda create -n $CONDA_ENV python=3.11 -y && \
+    echo "conda activate $CONDA_ENV" >> ~/.bashrc
+
+# Install Python dependencies
+RUN /opt/conda/bin/conda run -n $CONDA_ENV python3 -m pip install .
+
+# Install pytorch and pytorch_geometric dependencies
+RUN /opt/conda/bin/conda install pytorch cpuonly pytorch-scatter pytorch-sparse pyg -c pytorch -c pyg -y
+
+# Install Julia (optional) with non-interactive install
+RUN curl -fsSL https://install.julialang.org | sh -s -- -y && \
+    /opt/conda/bin/conda run -n $CONDA_ENV python3 -m pip install juliacall && \
+    . /root/.bashrc && \
+    . /root/.profile && \
+    julia -e 'import Pkg; Pkg.add("DifferentialEquations"); Pkg.add("DiffEqGPU"); Pkg.add("CUDA");'
+
+# Install fairchem and mace-torch (optional)
+RUN /opt/conda/bin/conda run -n $CONDA_ENV python3 -m pip install fairchem-core==1.1.0 && \
+    /opt/conda/bin/conda run -n $CONDA_ENV python3 -m pip install mace-torch torch-dftd
+
+# Add binaries from the project into PATH
+ENV PATH $PATH:/opt/conda/envs/care_env/bin
+
+# Copy logo into required place as required by hard-coded relative path
+RUN cp /care/src/care/logo.txt /opt/conda/envs/$CONDA_ENV/lib/python3.11/site-packages/care/
+
+# Create folder for data volume mount point
+RUN mkdir -p /data
+
+# Clean build artifacts from image
+RUN rm -rf /care
+
+# Set the entrypoint to run the gen_crn_blueprint command
+ENTRYPOINT ["gen_crn_blueprint", "-cs", "CCO", "C(CO)O", "-o", "/data/output_name"]
+
+# Default command (you can override this when running the container)
+CMD []

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Define the image name and tag
+IMAGE_NAME := care
+TAG := latest
+
+.PHONY: build run clean build-and-run debug status
+
+# Default target, build the Docker image only if it doesn't exist
+build:
+	docker build -t $(IMAGE_NAME):$(TAG) .;
+
+# Run the container (only build if the image is not present)
+run:
+	docker compose up --remove-orphans;
+
+# Clean up (optional, removes the image)
+clean:
+	docker compose down; \
+	docker rmi -f $(IMAGE_NAME):$(TAG);
+
+# Debug into the container
+debug:
+	docker compose run --entrypoint /bin/sh care;
+
+# Show the status of the container
+status:
+	docker ps -a | grep $(IMAGE_NAME);
+
+# For convenience, you can define a target to build and run together
+build-and-run: build run

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+---
+services:
+  care:
+    build:
+      context: .  # Build from the current directory (where the Dockerfile is located)
+      dockerfile: Dockerfile
+    image: care:latest  # Name and tag for the image
+    volumes:
+      - ./data:/data  # Mount ./data on the host to /data in the container


### PR DESCRIPTION
Hello,

Out of curiosity I wanted to try your software. 

Because I had some trouble with conda I preferred installing the dependencies inside a Docker container, so I created one with your project.

I thought that instead of keeping this to myself I could share it with you in case it might be useful. The Docker image is not very time or space optimized (~20 min build and ~20 GB size), but it can be used to run the software by only installing Docker. I was able to run the `gen_crn_blueprint` script with the examples you provide in the `README.md` of the repo. 

I also added a `Makefile` for convenience, but only Docker is needed to build or run the image. 

Tu run it via Docker, run the following shell commands:
```shell
cd care  
docker compose up  # sudo if required
```

or via `make`:
```shell
make run
```

I hope that it can be useful.





